### PR TITLE
Include table and column comments in metadata

### DIFF
--- a/src/Keboola/DbExtractor/Extractor/MySQL.php
+++ b/src/Keboola/DbExtractor/Extractor/MySQL.php
@@ -196,6 +196,7 @@ class MySQL extends Extractor
                 'schema' => (isset($table['TABLE_SCHEMA'])) ? $table['TABLE_SCHEMA'] : '',
                 'type' => (isset($table['TABLE_TYPE'])) ? $table['TABLE_TYPE'] : '',
                 'rowCount' => (isset($table['TABLE_ROWS'])) ? $table['TABLE_ROWS'] : '',
+                'description' => (isset($table['TABLE_COMMENT'])) ? $table['TABLE_COMMENT'] : ''
             ];
             if ($table["AUTO_INCREMENT"]) {
                 $tableDefs[$curTable]['autoIncrement'] = $table['AUTO_INCREMENT'];
@@ -240,6 +241,10 @@ class MySQL extends Extractor
                 "default" => $column['COLUMN_DEFAULT'],
                 "ordinalPosition" => $column['ORDINAL_POSITION'],
             ];
+
+            if ($column['COLUMN_COMMENT']) {
+                $curColumn['description'] = $column['COLUMN_COMMENT'];
+            }
 
             if (array_key_exists('CONSTRAINT_NAME', $column) && !is_null($column['CONSTRAINT_NAME'])) {
                 $curColumn['constraintName'] = $column['CONSTRAINT_NAME'];

--- a/src/Keboola/DbExtractor/Extractor/MySQL.php
+++ b/src/Keboola/DbExtractor/Extractor/MySQL.php
@@ -195,7 +195,7 @@ class MySQL extends Extractor
                 'name' => $table['TABLE_NAME'],
                 'schema' => (isset($table['TABLE_SCHEMA'])) ? $table['TABLE_SCHEMA'] : '',
                 'type' => (isset($table['TABLE_TYPE'])) ? $table['TABLE_TYPE'] : '',
-                'rowCount' => (isset($table['TABLE_ROWS'])) ? $table['TABLE_ROWS'] : ''
+                'rowCount' => (isset($table['TABLE_ROWS'])) ? $table['TABLE_ROWS'] : '',
             ];
             if ($table["TABLE_COMMENT"]) {
                 $tableDefs[$curTable]['description'] = $table['TABLE_COMMENT'];

--- a/src/Keboola/DbExtractor/Extractor/MySQL.php
+++ b/src/Keboola/DbExtractor/Extractor/MySQL.php
@@ -195,9 +195,11 @@ class MySQL extends Extractor
                 'name' => $table['TABLE_NAME'],
                 'schema' => (isset($table['TABLE_SCHEMA'])) ? $table['TABLE_SCHEMA'] : '',
                 'type' => (isset($table['TABLE_TYPE'])) ? $table['TABLE_TYPE'] : '',
-                'rowCount' => (isset($table['TABLE_ROWS'])) ? $table['TABLE_ROWS'] : '',
-                'description' => (isset($table['TABLE_COMMENT'])) ? $table['TABLE_COMMENT'] : ''
+                'rowCount' => (isset($table['TABLE_ROWS'])) ? $table['TABLE_ROWS'] : ''
             ];
+            if ($table["TABLE_COMMENT"]) {
+                $tableDefs[$curTable]['description'] = $table['TABLE_COMMENT'];
+            }
             if ($table["AUTO_INCREMENT"]) {
                 $tableDefs[$curTable]['autoIncrement'] = $table['AUTO_INCREMENT'];
             }

--- a/tests/Keboola/DbExtractor/AbstractMySQLTest.php
+++ b/tests/Keboola/DbExtractor/AbstractMySQLTest.php
@@ -62,11 +62,11 @@ abstract class AbstractMySQLTest extends ExtractorTest
         $this->pdo->exec('DROP TABLE IF EXISTS auto_increment_timestamp');
 
         $this->pdo->exec('CREATE TABLE auto_increment_timestamp (
-            `_weird-I-d` INT NOT NULL AUTO_INCREMENT,
-            `weird-Name` VARCHAR(30) NOT NULL DEFAULT \'pam\',
-            `timestamp` TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+            `_weird-I-d` INT NOT NULL AUTO_INCREMENT COMMENT \'This is a weird ID\',
+            `weird-Name` VARCHAR(30) NOT NULL DEFAULT \'pam\' COMMENT \'This is a weird name\',
+            `timestamp` TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT \'This is a timestamp\',
             PRIMARY KEY (`_weird-I-d`)  
-        )');
+        ) COMMENT=\'This is a table comment\'');
         $this->pdo->exec('INSERT INTO auto_increment_timestamp (`weird-Name`) VALUES (\'george\'), (\'henry\')');
     }
 

--- a/tests/Keboola/DbExtractor/MySQLTest.php
+++ b/tests/Keboola/DbExtractor/MySQLTest.php
@@ -229,6 +229,7 @@ class MySQLTest extends AbstractMySQLTest
                                     'ordinalPosition' => '1',
                                     'extra' => 'auto_increment',
                                     'autoIncrement' => '3',
+                                    'description' => 'This is a weird ID',
                                 ),
                             1 =>
                                 array (
@@ -240,6 +241,7 @@ class MySQLTest extends AbstractMySQLTest
                                     'nullable' => false,
                                     'default' => 'pam',
                                     'ordinalPosition' => '2',
+                                    'description' => 'This is a weird name',
                                 ),
                             2 =>
                                 array (
@@ -252,9 +254,11 @@ class MySQLTest extends AbstractMySQLTest
                                     'default' => 'CURRENT_TIMESTAMP',
                                     'ordinalPosition' => '3',
                                     'extra' => 'on update CURRENT_TIMESTAMP',
+                                    'description' => 'This is a timestamp',
                                 ),
                         ),
                     'timestampUpdateColumn' => 'timestamp',
+                    'description' => 'This is a table comment',
                 ),
             1 =>
                 array (
@@ -619,6 +623,7 @@ class MySQLTest extends AbstractMySQLTest
                                     'ordinalPosition' => '1',
                                     'extra' => 'auto_increment',
                                     'autoIncrement' => '3',
+                                    'description' => 'This is a weird ID',
                                 ),
                             1 =>
                                 array (
@@ -630,6 +635,7 @@ class MySQLTest extends AbstractMySQLTest
                                     'nullable' => false,
                                     'default' => 'pam',
                                     'ordinalPosition' => '2',
+                                    'description' => 'This is a weird name',
                                 ),
                             2 =>
                                 array (
@@ -642,9 +648,11 @@ class MySQLTest extends AbstractMySQLTest
                                     'default' => 'CURRENT_TIMESTAMP',
                                     'ordinalPosition' => '3',
                                     'extra' => 'on update CURRENT_TIMESTAMP',
+                                    'description' => 'This is a timestamp',
                                 ),
                         ),
                     'timestampUpdateColumn' => 'timestamp',
+                    'description' => 'This is a table comment',
                 ),
             2 =>
                 array (


### PR DESCRIPTION
partially fixes: #48 will require a UI update to pick up these descriptions

### Proposed changes:
- include table and column comments as description metadata
