### PR TITLE
use old mysql8 based on debian stretch (9)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,7 +58,7 @@ services:
       MYSQL_ROOT_PASSWORD: rootpassword
 
   mysql8:
-    image: mysql:8
+    image: mysql:8.0.18
     volumes:
         - ./tests/data/mysql/ssl:/ssl-cert
         - ./tests/data/mysql/conf.d:/etc/mysql/conf.d


### PR DESCRIPTION
Solving `PDOException: SQLSTATE[HY000] [2006] MySQL server has gone away`