### PR TITLE
Fix missing CMD in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,3 +41,5 @@ COPY . /code/
 
 # Run normal composer - all deps are cached already
 RUN composer install $COMPOSER_FLAGS
+
+CMD ["php", "/code/src/run.php", "--data=/data"]


### PR DESCRIPTION
Changelog:
 - Fix missing `CMD` on Dockerfile end
 - Sync action `testConnection` was failing with `Decoding JSON response from component failed: Syntax error`
 - Run action printed `Interactive sheel.` and ended without error.

Slack: https://keboola.slack.com/archives/CQ1ASK06M/p1589202390029200