### PR TITLE
Fix compatibility with PHP 7.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": "^7.3",
         "ext-PDO": "*",
-        "keboola/db-extractor-common": "^12.1",
+        "keboola/db-extractor-common": "^12.2",
         "keboola/db-extractor-config": "^1.2",
         "keboola/db-extractor-logger": "^1.0",
         "keboola/db-extractor-table-format": "^2.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "39a9f2cb1e9381e0fef7b84fdfbee4a7",
+    "content-hash": "b9d8b093860437dd85145f4523043dd5",
     "packages": [
         {
             "name": "keboola/common-exceptions",
@@ -91,16 +91,16 @@
         },
         {
             "name": "keboola/db-extractor-common",
-            "version": "12.1.0",
+            "version": "12.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/keboola/db-extractor-common.git",
-                "reference": "71b94319c42b648be5fb9263ddc656b03f58a69c"
+                "reference": "80576868050bdcbcdd9420eb645312e4324a5293"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/keboola/db-extractor-common/zipball/71b94319c42b648be5fb9263ddc656b03f58a69c",
-                "reference": "71b94319c42b648be5fb9263ddc656b03f58a69c",
+                "url": "https://api.github.com/repos/keboola/db-extractor-common/zipball/80576868050bdcbcdd9420eb645312e4324a5293",
+                "reference": "80576868050bdcbcdd9420eb645312e4324a5293",
                 "shasum": ""
             },
             "require": {
@@ -146,7 +146,7 @@
                 }
             ],
             "description": "Common library from Keboola Database Extractors",
-            "time": "2019-12-11T09:19:12+00:00"
+            "time": "2020-01-29T06:40:57+00:00"
         },
         {
             "name": "keboola/db-extractor-config",
@@ -2978,5 +2978,6 @@
         "php": "^7.3",
         "ext-pdo": "*"
     },
-    "platform-dev": []
+    "platform-dev": [],
+    "plugin-api-version": "1.1.0"
 }

--- a/tests/Keboola/DbExtractor/MySQLTest.php
+++ b/tests/Keboola/DbExtractor/MySQLTest.php
@@ -750,4 +750,15 @@ class MySQLTest extends AbstractMySQLTest
 
         $this->assertEquals('success', $result['status']);
     }
+
+    public function testIncrementalNotPresentNoResults(): void
+    {
+        $configurationArray = $this->getConfigRow(self::DRIVER);
+        unset($configurationArray['parameters']['incremental']);
+        $configurationArray['parameters']['query'] = 'SELECT * FROM sales WHERE 1 = 2;'; // no results
+        $app = $this->createApplication($configurationArray);
+        $result = $app->run();
+
+        $this->assertEquals('success', $result['status']);
+    }
 }


### PR DESCRIPTION
Changes:
- In `PHP 7.4` cannot be called `null['key']`, in `7.3` it results to `NULL` but in 7.4 it results to `ErrorException`.

Slack: https://keboola.slack.com/archives/CQ1ASK06M/p1589361711053800?thread_ts=1589202390.029200&cid=CQ1ASK06M