### PR TITLE
Fix BC, db.database can be empty + tests

### DIFF
--- a/src/Keboola/DbExtractor/Configuration/NodeDefinition/MysqlDbNode.php
+++ b/src/Keboola/DbExtractor/Configuration/NodeDefinition/MysqlDbNode.php
@@ -15,6 +15,12 @@ class MysqlDbNode extends DbNode
         $this->addNetworkCompression($builder);
     }
 
+    protected function addDatabaseNode(NodeBuilder $builder): void
+    {
+        // Database can be empty
+        $builder->scalarNode('database');
+    }
+
     protected function addNetworkCompression(NodeBuilder $builder): void
     {
         $builder->booleanNode('networkCompression')->defaultValue(false)->end();

--- a/tests/Keboola/DbExtractor/ConfigTest.php
+++ b/tests/Keboola/DbExtractor/ConfigTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\DbExtractor\Tests;
+
+use Keboola\DbExtractor\MySQLApplication;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\Test\TestLogger;
+
+class ConfigTest extends TestCase
+{
+    /**
+     * @dataProvider validConfigProvider
+     */
+    public function testValid(array $config): void
+    {
+        new MySQLApplication($config, new TestLogger());
+        $this->expectNotToPerformAssertions();
+    }
+
+    public function validConfigProvider(): array
+    {
+        return [
+            'no-database' => [
+                [
+                    'parameters' => [
+                        'db' => [
+                            'host' => 'mysql',
+                            'user' => 'root',
+                            '#password' => 'rootpassword',
+                            'port' => 3306,
+                        ],
+                        'query' => 'SELECT * FROM escaping',
+                        'outputTable' => 'in.c-main.escaping',
+                    ],
+                ],
+            ],
+            'empty-database' => [
+                [
+                    'parameters' => [
+                        'db' => [
+                            'host' => 'mysql',
+                            'user' => 'root',
+                            '#password' => 'rootpassword',
+                            'database' => '',
+                            'port' => 3306,
+                        ],
+                        'query' => 'SELECT * FROM escaping',
+                        'outputTable' => 'in.c-main.escaping',
+                    ],
+                ],
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
Changes:
- Database can be empty (`null`) in code: 
https://github.com/keboola/db-extractor-mysql/blob/c57a85bf77bacbf5bdd9a6f8984cbfe59482707b/src/Keboola/DbExtractor/Extractor/MySQL.php#L28
- But in `MysqlDbNode` was `cannotBeEmpty` from parent class.
- Fixed + added tests.