### PR TITLE
Parallel CI tests

### DIFF
--- a/.github/actions/ecr-login/action.yml
+++ b/.github/actions/ecr-login/action.yml
@@ -1,0 +1,12 @@
+name: ECR login
+description: Login to ECR with generated credentials
+runs:
+  using: "composite"
+  steps:
+    - name: ECR login
+      shell: bash
+      run: |
+        docker pull -q quay.io/keboola/developer-portal-cli-v2:latest
+        export ECR_URL=`docker run --rm -e KBC_DEVELOPERPORTAL_USERNAME -e KBC_DEVELOPERPORTAL_PASSWORD -e KBC_DEVELOPERPORTAL_URL quay.io/keboola/developer-portal-cli-v2:latest ecr:get-repository $KBC_DEVELOPERPORTAL_VENDOR $KBC_DEVELOPERPORTAL_APP`
+        eval $(docker run --rm -e KBC_DEVELOPERPORTAL_USERNAME -e KBC_DEVELOPERPORTAL_PASSWORD -e KBC_DEVELOPERPORTAL_URL quay.io/keboola/developer-portal-cli-v2:latest ecr:get-login $KBC_DEVELOPERPORTAL_VENDOR $KBC_DEVELOPERPORTAL_APP)
+        echo "ECR_URL=${ECR_URL}" >> $GITHUB_ENV

--- a/.github/actions/pull-image/action.yml
+++ b/.github/actions/pull-image/action.yml
@@ -1,0 +1,12 @@
+name: Pull image
+description: Pull image from ECR
+runs:
+  using: "composite"
+  steps:
+    - name: Pull image from ECR
+      shell: bash
+      run: |
+        echo "PULL: $ECR_URL:${GITHUB_REF##*/} -> $APP_IMAGE"
+        echo
+        docker pull $ECR_URL:${GITHUB_REF##*/}
+        docker tag $ECR_URL:${GITHUB_REF##*/} $APP_IMAGE

--- a/.github/actions/push-image/action.yml
+++ b/.github/actions/push-image/action.yml
@@ -1,0 +1,12 @@
+name: Push image
+description: Push image to ECR
+runs:
+  using: "composite"
+  steps:
+    - name: Push image to ECR
+      shell: bash
+      run: |
+        echo "PUSH: $APP_IMAGE -> $ECR_URL:${GITHUB_REF##*/}"
+        echo
+        docker tag $APP_IMAGE $ECR_URL:${GITHUB_REF##*/}
+        docker push $ECR_URL:${GITHUB_REF##*/}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,17 +1,23 @@
 name: GitHub Actions
-on: [push]
+on: [ push ]
+concurrency: ci-${{ github.ref }} # to avoid tag collisions in the ECR
 env:
-  APP_IMAGE: keboola/db-extractor-mysql
-  KBC_TEST_PROJECT_URL: "https://connection.keboola.com/admin/projects/2703/dashboard"
+  # Test image, must be same in the docker-compose.yml if used
+  APP_IMAGE: keboola/db-extractor-mysql:latest
+  # Developer portal login
   KBC_DEVELOPERPORTAL_VENDOR: "keboola"
   KBC_DEVELOPERPORTAL_APP: "keboola.ex-db-mysql"
   KBC_DEVELOPERPORTAL_USERNAME: "keboola+github_actions_db_extractor_mysql"
   KBC_DEVELOPERPORTAL_PASSWORD: ${{ secrets.KBC_DEVELOPERPORTAL_PASSWORD }}
+  # DockerHub login
   DOCKERHUB_USER: "keboolabot"
   DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+  # Test KBC project
   KBC_STORAGE_TOKEN: ${{ secrets.KBC_STORAGE_TOKEN }}
+  KBC_TEST_PROJECT_URL: "https://connection.keboola.com/admin/projects/2703/dashboard"
+  KBC_TEST_PROJECT_CONFIGS: "287537333 287589303 288410371 313935368" # space separated list
 jobs:
-  Build:
+  build:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
@@ -20,35 +26,60 @@ jobs:
         run: |
           docker -v
       - name: Build image
-        run: |
-          docker login --username "$DOCKERHUB_USER" --password "$DOCKERHUB_TOKEN"
-          docker build -t $APP_IMAGE .
-      - name: Run tests on MySQL 5
-        run: |
-          export MYSQL_VERSION=5.6
-          docker-compose run wait
-          docker-compose run app
-          docker-compose rm -s -f -v
-      - name: Run test on MySQL 8
-        run: |
-          export MYSQL_VERSION=8
-          docker-compose run wait
-          docker-compose run app
-          docker-compose rm -s -f -v
+        run: docker build -t $APP_IMAGE .
+      - name: Login to ECR
+        uses: ./.github/actions/ecr-login
       - name: Push image to ECR
+        uses: ./.github/actions/push-image
+
+  tests:
+    needs: build
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        mysql: [latest, 8, 5.6]
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+      - name: Login to ECR
+        uses: ./.github/actions/ecr-login
+      - name: Pull image from ECR
+        uses: ./.github/actions/pull-image
+      - name: Run tests
         run: |
-          docker pull quay.io/keboola/developer-portal-cli-v2:latest
-          export REPOSITORY=`docker run --rm -e KBC_DEVELOPERPORTAL_USERNAME -e KBC_DEVELOPERPORTAL_PASSWORD -e KBC_DEVELOPERPORTAL_URL quay.io/keboola/developer-portal-cli-v2:latest ecr:get-repository $KBC_DEVELOPERPORTAL_VENDOR $KBC_DEVELOPERPORTAL_APP`
-          docker tag $APP_IMAGE:latest $REPOSITORY:test
-          eval $(docker run --rm -e KBC_DEVELOPERPORTAL_USERNAME -e KBC_DEVELOPERPORTAL_PASSWORD -e KBC_DEVELOPERPORTAL_URL quay.io/keboola/developer-portal-cli-v2:latest ecr:get-login $KBC_DEVELOPERPORTAL_VENDOR $KBC_DEVELOPERPORTAL_APP)
-          docker push $REPOSITORY:test
-          docker pull quay.io/keboola/syrup-cli:latest
+          export MYSQL_VERSION="${{ matrix.mysql }}"
+          docker-compose run wait
+          docker-compose run app
+
+  tests-in-kbc:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
       - name: Run KBC test jobs
         run: |
-          docker run --rm -e KBC_STORAGE_TOKEN quay.io/keboola/syrup-cli:latest run-job keboola.ex-db-mysql 287537333 master
-          docker run --rm -e KBC_STORAGE_TOKEN quay.io/keboola/syrup-cli:latest run-job keboola.ex-db-mysql 287589303 master
-          docker run --rm -e KBC_STORAGE_TOKEN quay.io/keboola/syrup-cli:latest run-job keboola.ex-db-mysql 288410371 master
-          docker run --rm -e KBC_STORAGE_TOKEN quay.io/keboola/syrup-cli:latest run-job keboola.ex-db-mysql 313935368 master
+          docker pull -q quay.io/keboola/syrup-cli:latest
+          export TAG=${GITHUB_REF##*/}
+          TASK='
+            echo "Running config {} with tag $TAG ..."
+            docker run --rm -e KBC_STORAGE_TOKEN quay.io/keboola/syrup-cli:latest run-job keboola.ex-db-mysql {} $TAG
+          '
+          parallel --env TAG --halt now,fail=1 "$TASK" ::: $KBC_TEST_PROJECT_CONFIGS
+          echo "OK"
+  deploy:
+    needs:
+      - tests
+      - tests-in-kbc
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
+    steps:
+      - name: Login to ECR
+        uses: ./.github/actions/ecr-login
+      - name: Pull image from ECR
+        uses: ./.github/actions/pull-image
+      - name: Docker login
+        run: docker login --username "$DOCKERHUB_USER" --password "$DOCKERHUB_TOKEN"
       - name: Deploy
-        if: startsWith(github.ref, 'refs/tags/')
         run: ./deploy.sh

--- a/deploy.sh
+++ b/deploy.sh
@@ -30,7 +30,7 @@ then
         -e KBC_DEVELOPERPORTAL_USERNAME \
         -e KBC_DEVELOPERPORTAL_PASSWORD \
         quay.io/keboola/developer-portal-cli-v2:latest \
-        update-app-repository ${KBC_DEVELOPERPORTAL_VENDOR} ${KBC_DEVELOPERPORTAL_APP} ${GITHUB_TAG} ecr ${REPOSITORY}
+        update-app-repository ${KBC_DEVELOPERPORTAL_VENDOR} ${KBC_DEVELOPERPORTAL_APP} ${GITHUB_TAG} ecr ${ECR_URL}
 else
     echo "Skipping deployment to KBC, tag ${GITHUB_TAG} is not allowed."
 fi


### PR DESCRIPTION
Changes:
- Run CI and KBC tests in parallel.
- It is 2x faster, and other versions of the MySQL server can be easly added to the tests.

![image](https://user-images.githubusercontent.com/19371734/130392566-057f2b0c-29dd-4717-80a0-e2948d5ec215.png)
