### PR TITLE
TMP: Set wait_timeout

### DIFF
--- a/src/Keboola/DbExtractor/Extractor/MySQLDbConnectionFactory.php
+++ b/src/Keboola/DbExtractor/Extractor/MySQLDbConnectionFactory.php
@@ -83,6 +83,15 @@ class MySQLDbConnectionFactory
                     $pdo->exec('SET NAMES utf8;');
                 }
 
+                // Set wait_timeout
+                try {
+                    $logger->warning('Current wait_timeout ' . $pdo->query('SELECT @@wait_timeout')->fetchColumn());
+                    $pdo->exec('SET SESSION wait_timeout = 300;');
+                    $logger->warning('New wait_timeout ' . $pdo->query('SELECT @@wait_timeout')->fetchColumn());
+                } catch (PDOException $exception) {
+                    $logger->error('Error setting wait_timeout.');
+                }
+
                 // Set isolation level
                 if ($dbConfig->hasTransactionIsolationLevel()) {
                     $pdo->query(


### PR DESCRIPTION
```bash
Set PDO options: 2,
Creating PDO connection to "mysql:host=martin-alternat-mysql-timeouts-st-514-mysql.ce0qbaqf0bka.us-east-1.rds.amazonaws.com;port=3306;charset=utf8;dbname=demo".
Current wait_timeout 28800
New wait_timeout 300
Exporting to "test".
Query: SELECT * FROM test
Query: SELECT 1
Query result set is empty. Exported "0" rows to "test".

```