### PR TITLE
docs: add timezone configuration workaround for Azure MySQL (SUPPORT-13936)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,32 @@ The configuration requires a `db` node with the following properties:
   - sshPort string
   - maxRetries integer
 - transactionIsolationLevel: enum (optional) - possible values `REPEATABLE READ`, `READ COMMITTED`, `READ UNCOMMITTED`, `SERIALIZABLE`
-   
+- initQueries: array of strings (optional) - SQL queries to execute on connection initialization
+
+#### Timezone Configuration
+
+By default, the extractor uses the MySQL server's session timezone setting. To ensure consistent UTC timestamps across all environments (especially when using Azure MySQL), you can set the session timezone explicitly using `initQueries`:
+
+```json
+{
+  "db": {
+    "host": "your-host",
+    "port": "3306",
+    "user": "your-user",
+    "#password": "your-password",
+    "database": "your-database",
+    "initQueries": [
+      "SET SESSION time_zone = '+00:00'"
+    ]
+  }
+}
+```
+
+This is particularly important when:
+- Extracting TIMESTAMP columns (which are converted based on session timezone)
+- Working with Azure MySQL instances that may default to non-UTC timezones
+- Ensuring consistent behavior across different cloud providers (AWS, GCP, Azure)
+
 There are 2 possible types of table extraction.  
 1. A table defined by `schema` and `tableName`, this option can also include a columns list.
 2. A `query` which is the SQL SELECT statement to be executed to produce the result table.


### PR DESCRIPTION
# docs: add timezone configuration workaround for Azure MySQL (SUPPORT-13936)

## Summary
Added documentation for the `initQueries` configuration parameter and created a new "Timezone Configuration" section in the README with a workaround for Azure MySQL timezone inconsistencies.

**Background**: Azure MySQL instances may default to non-UTC timezones (e.g., Europe/London), causing inconsistent TIMESTAMP extraction behavior compared to AWS and GCP stacks. This PR documents the existing `initQueries` feature as a workaround to explicitly set session timezone to UTC.

**Changes**:
- Documented the `initQueries` parameter in the configuration options list
- Added new "Timezone Configuration" section with example JSON configuration
- Explained when and why this workaround is needed (TIMESTAMP columns, Azure MySQL, cross-provider consistency)

**Important**: This is a documentation-only change. No code modifications were made because changing the default timezone behavior would break existing Azure users' data (per discussion with @ZdenekSrotyr).

## Review & Testing Checklist for Human
- [ ] Verify the documented workaround is technically accurate (the `initQueries` feature exists and is tested in `tests/functional/run-action-with-init-queries`, but hasn't been tested specifically with timezone setting)
- [ ] Check if the explanation is clear enough for users encountering the Azure timezone issue
- [ ] Confirm the JSON example follows Keboola configuration conventions

### Notes
- The `initQueries` configuration parameter is already implemented and tested (see `tests/functional/run-action-with-init-queries`)
- Code analysis confirmed that `initQueries` is properly defined in the configuration schema (`DbNode.php:85-88`)
- This addresses SUPPORT-13936 without breaking existing Azure users' pipelines that may depend on the current Europe/London timezone behavior

**Session**: https://app.devin.ai/sessions/59ca01ad8fb94b5590e848afaf550c27  
**Requested by**: zdenek.srotyr@keboola.com (@ZdenekSrotyr)