### PR TITLE
fix: update db-extractor-common to 17.2.3 to support legacy SSH keys

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -230,7 +230,7 @@
         },
         {
             "name": "keboola/db-extractor-common",
-            "version": "17.2.2",
+            "version": "17.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/keboola/db-extractor-common.git",
@@ -300,7 +300,7 @@
             ],
             "description": "Common library from Keboola Database Extractors",
             "support": {
-                "source": "https://github.com/keboola/db-extractor-common/tree/17.2.2"
+                "source": "https://github.com/keboola/db-extractor-common/tree/17.2.3"
             },
             "time": "2026-01-26T09:02:51+00:00"
         },
@@ -348,7 +348,7 @@
         },
         {
             "name": "keboola/db-extractor-ssh-tunnel",
-            "version": "1.3.1",
+            "version": "1.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/keboola/db-extractor-ssh-tunnel.git",
@@ -385,7 +385,7 @@
             "description": "Create SSH tunnel for DB Extractors",
             "support": {
                 "issues": "https://github.com/keboola/db-extractor-ssh-tunnel/issues",
-                "source": "https://github.com/keboola/db-extractor-ssh-tunnel/tree/1.3.1"
+                "source": "https://github.com/keboola/db-extractor-ssh-tunnel/tree/1.3.2"
             },
             "time": "2026-01-23T15:24:19+00:00"
         },
@@ -771,16 +771,16 @@
         },
         {
             "name": "keboola/ssh-tunnel",
-            "version": "2.2.1",
+            "version": "2.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/keboola/ssh-tunnel.git",
-                "reference": "518625f9d0fca2ab7c5fb49aec9a6229b71a0f45"
+                "reference": "0580cb07030943496727077b35567ff555281d6e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/keboola/ssh-tunnel/zipball/518625f9d0fca2ab7c5fb49aec9a6229b71a0f45",
-                "reference": "518625f9d0fca2ab7c5fb49aec9a6229b71a0f45",
+                "url": "https://api.github.com/repos/keboola/ssh-tunnel/zipball/0580cb07030943496727077b35567ff555281d6e",
+                "reference": "0580cb07030943496727077b35567ff555281d6e",
                 "shasum": ""
             },
             "require": {
@@ -811,9 +811,9 @@
             "description": "Simple library for SSH tunneling",
             "support": {
                 "issues": "https://github.com/keboola/ssh-tunnel/issues",
-                "source": "https://github.com/keboola/ssh-tunnel/tree/2.2.1"
+                "source": "https://github.com/keboola/ssh-tunnel/tree/2.2.2"
             },
-            "time": "2026-01-23T11:42:42+00:00"
+            "time": "2026-01-29T15:09:57+00:00"
         },
         {
             "name": "monolog/monolog",
@@ -3432,16 +3432,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v6.4.32",
+            "version": "v6.4.33",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "c593135be689b21e6164b1e8f6f5dbf1506b065c"
+                "reference": "c46e854e79b52d07666e43924a20cb6dc546644e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/c593135be689b21e6164b1e8f6f5dbf1506b065c",
-                "reference": "c593135be689b21e6164b1e8f6f5dbf1506b065c",
+                "url": "https://api.github.com/repos/symfony/process/zipball/c46e854e79b52d07666e43924a20cb6dc546644e",
+                "reference": "c46e854e79b52d07666e43924a20cb6dc546644e",
                 "shasum": ""
             },
             "require": {
@@ -3473,7 +3473,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v6.4.32"
+                "source": "https://github.com/symfony/process/tree/v6.4.33"
             },
             "funding": [
                 {
@@ -3493,7 +3493,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-15T13:23:20+00:00"
+            "time": "2026-01-23T16:02:12+00:00"
         },
         {
             "name": "symfony/property-access",


### PR DESCRIPTION
## Why

Some users' SSH configurations still use legacy `ssh-rsa` keys for SSH tunnel connections. The previous version of the SSH tunnel library didn't properly support these legacy key types, causing connection failures for these users.

## Context

This is related to ticket ST-3472. The upstream `db-extractor-common` library (version 17.2.3) and its dependency chain (`db-extractor-ssh-tunnel` 1.3.2, `ssh-tunnel` 2.2.2) have been updated to properly handle legacy SSH key algorithms.

## Approach

Updated the `db-extractor-common` dependency to version 17.2.3, which pulls in the necessary SSH tunnel library updates that add support for legacy `ssh-rsa` keys.

## Impact

- Restores compatibility with SSH servers using legacy `ssh-rsa` key algorithms
- No breaking changes - existing configurations continue to work
- Enables users with older SSH infrastructure to connect successfully

## Testing

Standard CI tests will validate the integration works correctly.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)