### PR TITLE
feat: output NULL values as empty unquoted fields in CSV

### DIFF
--- a/src/Keboola/DbExtractor/Extractor/MySQLResultWriter.php
+++ b/src/Keboola/DbExtractor/Extractor/MySQLResultWriter.php
@@ -21,6 +21,53 @@ class MySQLResultWriter extends DefaultResultWriter
         return false;
     }
 
+    protected function createCsvWriter(string $csvFilePath): CsvWriter
+    {
+        $dir = dirname($csvFilePath);
+        if (!is_dir($dir)) {
+            mkdir($dir, 0777, true);
+        }
+
+        return new NullAwareCsvWriter($csvFilePath);
+    }
+
+    protected function writeRow(array $row, CsvWriter $csvWriter): void
+    {
+        if ($this->fromEncoding && $this->toEncoding) {
+            $row = $this->convertEncodingPreservingNulls(
+                $row,
+                $this->fromEncoding,
+                $this->toEncoding,
+                $this->ignoreInvalidUtf8,
+            );
+        }
+
+        $csvWriter->writeRow($row);
+    }
+
+    /**
+     * Like convertEncodingInArray, but preserves NULL values instead of casting them to empty string.
+     */
+    private function convertEncodingPreservingNulls(
+        array $row,
+        string $from,
+        string $to,
+        bool $ignoreInvalidUtf8,
+    ): array {
+        return array_map(
+            function ($value) use ($from, $to, $ignoreInvalidUtf8) {
+                if ($value === null) {
+                    return null;
+                }
+                if ($ignoreInvalidUtf8) {
+                    return mb_convert_encoding((string) $value, $from, $to);
+                }
+                return iconv($from, $to, (string) $value);
+            },
+            $row,
+        );
+    }
+
     public function writeToCsv(
         QueryResult $result,
         ExportConfig $exportConfig,

--- a/src/Keboola/DbExtractor/Extractor/NullAwareCsvWriter.php
+++ b/src/Keboola/DbExtractor/Extractor/NullAwareCsvWriter.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\DbExtractor\Extractor;
+
+use Keboola\Csv\CsvWriter;
+use Keboola\Csv\Exception;
+
+/**
+ * CsvWriter that outputs NULL values as empty (unquoted) fields instead of quoted empty strings.
+ * This means NULL -> ,, instead of ,"",
+ */
+class NullAwareCsvWriter extends CsvWriter
+{
+    public function rowToStr(array $row): string
+    {
+        $return = [];
+        foreach ($row as $column) {
+            if ($column === null) {
+                $return[] = '';
+                continue;
+            }
+
+            if (!(
+                is_scalar($column)
+                || (
+                    is_object($column)
+                    && method_exists($column, '__toString')
+                )
+            )) {
+                throw new Exception(
+                    'Cannot write data into column: ' . var_export($column, true),
+                    Exception::WRITE_ERROR,
+                );
+            }
+
+            $return[] = $this->getEnclosure() .
+                str_replace($this->getEnclosure(), str_repeat($this->getEnclosure(), 2), (string) $column) .
+                $this->getEnclosure();
+        }
+        return implode($this->getDelimiter(), $return) . "\n";
+    }
+}

--- a/tests/functional/convert-bin-to-hex-null-value/expected/data/out/tables/in.c-main.binary-child.csv
+++ b/tests/functional/convert-bin-to-hex-null-value/expected/data/out/tables/in.c-main.binary-child.csv
@@ -1,4 +1,4 @@
 "1","3f1256","Child 1"
 "2","aa4234","Child 2"
-"3","","Child with NULL FK"
-"4","ffa500","Child 4" 
+"3",,"Child with NULL FK"
+"4","ffa500","Child 4"  


### PR DESCRIPTION
## Summary

Changes the MySQL extractor's CSV output so that SQL `NULL` values are written as empty unquoted fields (`,,`) instead of quoted empty strings (`,"",`). This allows downstream consumers to distinguish `NULL` from an actual empty string.

**Before:** `"foo","","bar"` (NULL and empty string both become `""`)
**After:** `"foo",,"bar"` (NULL becomes unquoted empty, empty string stays `""`)

Two changes:
1. **New `NullAwareCsvWriter`** — extends `Keboola\Csv\CsvWriter`, overrides `rowToStr()` to skip enclosure wrapping for `null` values.
2. **Modified `MySQLResultWriter`** — overrides `createCsvWriter()` to use `NullAwareCsvWriter`, and overrides `writeRow()` with a null-preserving encoding conversion (the parent's `convertEncodingInArray` casts all values to `(string)`, which turns `null` into `""`).

### Updates since last revision
- Updated the `convert-bin-to-hex-null-value` functional test fixture to match the new NULL output format (`"3",,"Child with NULL FK"` instead of `"3","","Child with NULL FK"`). This was the only test failure across all three MySQL version matrices (5.6, 8, 9.1).

## Review & Testing Checklist for Human

- [ ] **Keboola Storage API compatibility**: Verify that unquoted empty CSV fields are correctly interpreted as NULL (not empty string) when imported into Storage. This is the entire purpose of the change and cannot be verified from static analysis alone.
- [ ] **Hardcoded newline in `NullAwareCsvWriter`**: `rowToStr()` hardcodes `"\n"` instead of using the parent's `$this->lineBreak` property (which is private). Confirm this is acceptable or if it needs to respect the constructor's `$lineBreak` parameter.
- [ ] **No new tests added**: There are no unit tests for `NullAwareCsvWriter::rowToStr()`. Only the existing functional test fixture was updated. Consider adding a unit test for the new writer.
- [ ] **Downstream impact**: This is a behavioral change in CSV output format. Confirm no other consumers of this extractor's output rely on the previous `""` representation for NULLs.

**Recommended test plan**: Run the extractor against a MySQL table containing columns with NULL values, empty strings, and regular values. Inspect the raw CSV output to confirm NULLs produce `,,` and empty strings produce `,"",`. Then import the CSV into Keboola Storage and verify the values are stored correctly.

### Notes
- `NullAwareCsvWriter::rowToStr()` duplicates validation/formatting logic from the parent `CsvWriter`. If the parent is updated upstream, this override won't inherit those changes.
- phpcs and phpstan pass at max level.
- `tests-in-kbc` CI job failure is due to an invalid Storage API token (infrastructure issue), not related to this change.

## Release Notes
**Justification, description**

Modified CSV output to write SQL NULL values as empty unquoted fields instead of quoted empty strings, enabling downstream distinction between NULL and empty string.

**Plans for Customer Communication**

N/A — this is intended as a custom fork for specific use.

**Impact Analysis**

Breaking change in CSV output format for NULL values. Any system parsing the output that expects all fields to be enclosed will see different behavior.

**Deployment Plan**

Branch build, test via `runtime.tag` configuration.

**Rollback Plan**

Revert to standard `keboola.ex-db-mysql` component (no `runtime.tag` override).

**Post-Release Support Plan**

N/A

Link to Devin session: https://app.devin.ai/sessions/c1ac3bbed74a4bb1933a9493b6932428
Requested by: @yustme